### PR TITLE
Fix broken link

### DIFF
--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -271,7 +271,7 @@
 			</p>
 
 			<Button
-				href="https://github.com/lipu-linku/ijo/blob/main/survey/2023/results.md"
+				href="https://github.com/lipu-linku/ijo/blob/main/survey/2023/README.md"
 				target="_blank"
 				rel="noopener noreferrer"
 				class="whitespace-nowrap"


### PR DESCRIPTION
Currently https://linku.la/about has a broken link:
![image](https://github.com/lipu-linku/lipu/assets/14614115/e9077c1f-b3db-40af-b3bb-dd2423a26335)
![image](https://github.com/lipu-linku/lipu/assets/14614115/2e90ffef-6f15-41f2-a354-06ff694c8b3d)

I assume `README.md` was intended instead. sina pona!