### PR TITLE
add support for legacy jasima data.json

### DIFF
--- a/src/routes/jasima/data.json/+server.ts
+++ b/src/routes/jasima/data.json/+server.ts
@@ -1,12 +1,9 @@
+import { client } from "@kulupu-linku/sona/client";
 import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 
 export const GET: RequestHandler = async ({ fetch, setHeaders }) => {
-	const r = await fetch(
-		"https://raw.githubusercontent.com/lipu-linku/jasima/main/data.json"
-	).then(r => r.json());
-
 	setHeaders({ "Cache-Control": "s-maxage=31536000" });
 
-	return json(r);
+	return await client({ fetch }).jasima.$get();
 };

--- a/src/routes/jasima/data.json/+server.ts
+++ b/src/routes/jasima/data.json/+server.ts
@@ -1,0 +1,12 @@
+import { json } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({ fetch, setHeaders }) => {
+	const r = await fetch(
+		"https://raw.githubusercontent.com/lipu-linku/jasima/main/data.json"
+	).then(r => r.json());
+
+	setHeaders({ "Cache-Control": "s-maxage=31536000" });
+
+	return json(r);
+};


### PR DESCRIPTION
this pr re-adds support for `https://linku.la/jasima/data.json` as a link by forwarding the data sent from the raw github link

idk if this should actually be added because i know you want to discourage the use of jasima, so feel free to close it

but i think it would be useful to not break some old projects even if they're tiny ones like [this one](https://github.com/jan-Piljan/ilo-sona-nimi-lili/blob/main/ilo.py)