### PR TITLE
Auto-focus the search field

### DIFF
--- a/src/routes/(words)/WordsSearch.svelte
+++ b/src/routes/(words)/WordsSearch.svelte
@@ -80,6 +80,7 @@
 		type="search"
 		name="q"
 		required
+		autofocus
 		autocapitalize="off"
 		autocomplete="off"
 		bind:value={searchQuery.value}


### PR DESCRIPTION
This lets you type right away when you load the page rather than having to click the field or navigate to it using the tab key.