### PR TITLE
fix: add checks for malformed translation data

### DIFF
--- a/src/routes/Entry.svelte
+++ b/src/routes/Entry.svelte
@@ -88,7 +88,7 @@
 						.map((etym, i) => {
 							const local_etym = etymology[i];
 							return (
-								(local_etym?.language ? local_etym.language : "?") +
+								(local_etym?.language ? local_etym.language : "unknown") +
 								(etym.word ? `: ${etym.word}` : "") +
 								(etym.alt ? ` (${etym.alt})` : "") +
 								(local_etym?.definition ? ` - ${local_etym.definition}` : "")


### PR DESCRIPTION
Resolves page crash on sandbox page when the translation is completely missing (by replacing text with "_no translation available_") and not erroring when etymology translation count is mismatched (by replacing language with "unknown" and excluding the word definition.