### PR TITLE
feat(perf): search input page reflow debounce and auto-select on hotkey

### DIFF
--- a/src/routes/(words)/WordsSearch.svelte
+++ b/src/routes/(words)/WordsSearch.svelte
@@ -27,7 +27,9 @@
 	const focusSearch = (e: KeyboardEvent) => {
 		if (e.key === "/" && document.activeElement?.id !== "search-input") {
 			e.preventDefault();
-			document.getElementById("search-input")!.focus();
+			let si = document.getElementById("search-input")!;
+			si.focus()
+			si.select();
 		}
 	};
 
@@ -55,9 +57,23 @@
 		pushState(page.url, {});
 	};
 
+	let defaultDebounceMS = 500;
+	let targetMS = $state(defaultDebounceMS);
+	let tempQuery = $state('');
 	$effect(() => {
+		if (targetMS > 0) {
+			const debounceInterval = setTimeout(() => {
+				queryParams.q = tempQuery;
+			}, targetMS);
+		}
 		if (queryParams.q === "") clearQuery();
 	});
+
+	const renewDebounceTimer = (newTargetMS) => {
+		if (newTargetMS > 0) {
+			targetMS = newTargetMS;
+		}
+	}
 </script>
 
 <svelte:window onkeydown={focusSearch} />
@@ -99,7 +115,8 @@
 			required
 			autocapitalize="off"
 			autocomplete="off"
-			bind:value={queryParams.q}
+			on:input={() => renewDebounceTimer(defaultDebounceMS)}
+			bind:value={tempQuery}
 			id="search-input"
 		/>
 		<Button


### PR DESCRIPTION
Some polishing efforts on the performance and behavior of the input element in `WordsSearch.svelte`.

With the new website, my input was lagging due to the auto-search during `queryParams.q` updates. Never used svelte before but this adds a short (500ms, not parameterized but could be) "debounce" do the query parameter update, allowing one to type quickly in a full string without losing keypresses due to page becoming unresponsive when presenting the search results.

Example of before:
<img width="265" height="110" alt="image" src="https://github.com/user-attachments/assets/47228c36-1f4c-4b7c-905a-12a89220cc2b" />

I captured performance also, but I didn't look at it too closely. In the end, with this patch, I don't lose characters while typing a search and can find the website easier to use.

<img width="1919" height="933" alt="image" src="https://github.com/user-attachments/assets/6dbfe126-fa0f-412a-8cdb-c6bef214d674" />

As for the auto-selecting of the search box on pressing the hotkey `/`, that is standardizing...