### PR TITLE
fix favorite order when no search is applied

### DIFF
--- a/src/lib/components/search.svelte.ts
+++ b/src/lib/components/search.svelte.ts
@@ -27,8 +27,8 @@ export const wordSearch = (
 
 	if (query === "")
 		return initialFilteredWords.sort((a, b) => {
-			if (favorites.includes(a.id)) return -1;
-			if (favorites.includes(b.id)) return 1;
+			if (a.isFavorite && !b.isFavorite) return -1;
+			if (!a.isFavorite && b.isFavorite) return 1;
 			return a.word.toLowerCase().localeCompare(b.word.toLowerCase());
 		});
 


### PR DESCRIPTION
#68 still had an issue with the generic word sorting function when no search was applied. this fixes that by still comparing within favorited words